### PR TITLE
Added support for GDC manifest files.

### DIFF
--- a/bin/client.py
+++ b/bin/client.py
@@ -3,12 +3,22 @@ import parcel
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('file_ids', metavar='file_id', type=str, nargs='+',
+    parser.add_argument('file_ids', metavar='file_id', type=str, nargs='*',
                         help='uuids to download')
     parser.add_argument('-t', '--token', default='', type=str,
                         help='authentication token')
+    # NOTE should we allow this in combination w/ other file_ids?
+    parser.add_argument('-m', '--manifest', type=argparse.FileType('r'),
+                        help='GDC Download anifest file.')
 
     args = parser.parse_args()
+
     client = parcel.Client(args.token)
+
+    manifest = parcel.manifest.parse(args.manifest) if args.manifest else []
+    for entry in manifest:
+        # TODO client to interpret other manifest fields
+        client.download(entry['uuid'])
+
     for file_id in args.file_ids:
         client.download(file_id)

--- a/parcel/__init__.py
+++ b/parcel/__init__.py
@@ -9,6 +9,8 @@ import signal
 from functools import wraps
 from multiprocessing import Process
 
+import manifest
+
 from const import (
     # Lengths
     LEN_CONTROL, LEN_PAYLOAD_SIZE,

--- a/parcel/manifest.py
+++ b/parcel/manifest.py
@@ -1,0 +1,16 @@
+import csv
+
+def parse(fd, delimiter='\t', quotechar='#', **kwargs):
+    """Parses a manifest file string.
+    
+    :param fd:
+        A file-like object containing a GDC manifest
+    """
+
+    manifest = csv.DictReader(fd,
+        delimiter=delimiter,
+        quotechar=quotechar,
+    )
+
+    for row in manifest:
+        yield row


### PR DESCRIPTION
Adds new parser flag -m / --manifest taking in a readable file descriptor.
Adds new manifest module, only exposes parse function atm.
Will now download files from both manifest and command line.

@millerjs 