### PR TITLE
Pubkey auth.

### DIFF
--- a/bin/gen-key
+++ b/bin/gen-key
@@ -1,0 +1,14 @@
+#!/usr/bin/env python2
+
+import Crypto
+from Crypto.PublicKey import RSA
+from Crypto import Random
+
+KEY_LENGTH = 4096
+random_gen = Random.new().read
+
+key = RSA.generate(KEY_LENGTH, random_gen)
+pub = key.publickey()
+
+print(key.exportKey())
+print(pub.exportKey())

--- a/bin/parcel
+++ b/bin/parcel
@@ -18,6 +18,7 @@ def get_client(args, token):
             host=args.host,
             port=args.port,
             n_threads=args.n_threads,
+            pubkey=args.pubkey,
         )
     elif args.mode == 'https':
         client = parcel.HTTPClient(
@@ -65,6 +66,15 @@ if __name__ == '__main__':
                      'Defaults to current dir')
     udt.add_argument('-x', '--no-stats', action='store_true',
                      help='turn off statistics printing')
+
+    # Server public key options.
+    udt.add_argument('-K', '--keyfile',
+        dest='pubkey',
+        default=None,
+        type=lambda x: argparse.FileType('r')(x).read(),
+        help='Server RSA public key file.',
+    )
+
     # Add token args
     token_args = udt.add_mutually_exclusive_group(required=False)
     token_args.add_argument('-t', '--token-file', default='', type=str,

--- a/bin/parcel-server
+++ b/bin/parcel-server
@@ -15,6 +15,7 @@ def main(args):
         'data_server_url': args.data_server_url,
         'max_enc_threads': args.max_threads,
         'buffer_processes': args.buffer_processes,
+        'prikey': args.prikey,
     }
 
     server = parcel.Server()
@@ -35,6 +36,16 @@ if __name__ == '__main__':
                         help='encryption threads to grant client')
     parser.add_argument('-b', '--buffer_processes', type=int, default=8,
                         help='Number of processes to use for async buffering from API')
+
+    # Server private key options.
+    parser.add_argument('-K', '--keyfile',
+        dest='prikey',
+        default=None,
+        type=lambda x: argparse.FileType('r')(x).read(),
+        help='Server RSA private key file.',
+    )
+
+
     args = parser.parse_args()
 
     main(args)

--- a/parcel/auth.py
+++ b/parcel/auth.py
@@ -1,0 +1,80 @@
+from base64 import b64encode
+from base64 import b64decode
+
+from Crypto import Random
+from Crypto.Hash import SHA
+from Crypto.Cipher import AES
+from Crypto.Cipher import PKCS1_OAEP
+from Crypto.PublicKey import RSA
+from Crypto.Signature import PKCS1_PSS
+
+
+KEY_LENGTH = 4096  # Key size (in bits)
+random_gen = Random.new().read
+
+
+def server_auth(send, recv, key, **opts):
+    '''Perform server-side pubkey authentication.
+
+    :param send: Function taking one positional argument, payload to client.
+    :param recv: Function taking no positional arguments, payload from client.
+    :param key: String serialized server private key.
+
+    Returns the symmetric key and initialization vector.
+    '''
+
+    # TODO respond with error on failure
+    
+    server_key = RSA.importKey(key)
+    server_dec = PKCS1_OAEP.new(server_key)
+
+    client_key = RSA.importKey(b64decode(recv(**opts)))
+    client_enc = PKCS1_OAEP.new(client_key)
+
+    msg = server_dec.decrypt(b64decode(recv(**opts)))
+    msg = SHA.new(msg)
+    msg = PKCS1_PSS.new(server_key).sign(msg)
+    send(b64encode(msg))
+    
+    k = Random.new().read(AES.block_size)
+    i = Random.new().read(AES.block_size)
+
+    send(b64encode(client_enc.encrypt(k + i)), **opts)
+
+    return k,i
+
+
+def client_auth(send, recv, key, **opts):
+    '''Perform client-side pubkey authentication.
+
+    :param send: Function taking one positional argument, payload to server.
+    :param recv: Function taking no positional arguments, payload from server.
+    :param key: String serialized server public key.
+
+    Returns the symmetric key and initialization vector.
+    '''
+
+    # TODO respond with error on failure
+    
+    server_key = RSA.importKey(key)
+    server_enc = PKCS1_OAEP.new(server_key)
+    
+    client_key = RSA.generate(KEY_LENGTH, random_gen)
+    client_dec = PKCS1_OAEP.new(client_key)
+
+    client_pub = client_key.publickey().exportKey()
+    send(b64encode(client_pub), **opts)
+
+    msg = random_gen(4)
+    send(b64encode(server_enc.encrypt(msg)), **opts)
+
+    msg = SHA.new(msg)
+    res = b64decode(recv())
+    if not PKCS1_PSS.new(server_key).verify(msg, res):
+        log.debug('Signature failed validation.')
+        raise ValueError('Server signature invalid.')
+
+    res = client_dec.decrypt(b64decode(recv(**opts)))
+    k,i = res[:len(res)/2], res[len(res)/2:]
+
+    return k,i

--- a/parcel/client.py
+++ b/parcel/client.py
@@ -2,6 +2,7 @@ import os
 import time
 import atexit
 
+from parcel import auth
 from parcel_thread import ParcelThread
 from multiprocessing.pool import ThreadPool
 from utils import state_method, print_download_information, monitor_transfer
@@ -54,7 +55,7 @@ class UDTClient(Client):
         self.n_threads = n_threads
         self.token = token
 
-        self.pubkey = None
+        self.pubkey = pubkey
         self.key = None
         self.iv = None
 
@@ -91,10 +92,11 @@ class UDTClient(Client):
     @state_method('handshake')
     def authenticate(self):
         if self.pubkey: # Server public key specified - perform exchange.
+            log.info('Performing pubkey handshake.')
             self.key, self.iv = auth.client_auth(
                 self.send_payload,
                 self.next_payload,
-                self.key,
+                self.pubkey,
                 encryption=False,
             )
         # TODO need to move token passing to after encryption has been enabled

--- a/parcel/client.py
+++ b/parcel/client.py
@@ -49,10 +49,14 @@ class Client(ParcelThread):
 class UDTClient(Client):
 
     def __init__(self, token, host='localhost', port=9000,
-                 n_threads=4):
+                 n_threads=4, pubkey=None):
 
         self.n_threads = n_threads
         self.token = token
+
+        self.pubkey = None
+        self.key = None
+        self.iv = None
 
         client = lib.new_client()
         log.info('Connecting to server at {}:{}'.format(host, port))
@@ -86,6 +90,14 @@ class UDTClient(Client):
 
     @state_method('handshake')
     def authenticate(self):
+        if self.pubkey: # Server public key specified - perform exchange.
+            self.key, self.iv = auth.client_auth(
+                self.send_payload,
+                self.next_payload,
+                self.key,
+                encryption=False,
+            )
+        # TODO need to move token passing to after encryption has been enabled
         self.send_payload(self.token)
 
     def close(self):

--- a/parcel/sthread.py
+++ b/parcel/sthread.py
@@ -80,10 +80,11 @@ class ServerThread(ParcelThread):
 
         """
         if self.prikey: # Server private key specified - perform exchange.
+            log.info('Performing pubkey handshake.')
             self.key, self.iv = auth.server_auth(
                 self.send_payload,
                 self.next_payload,
-                self.key,
+                self.prikey,
                 encryption=False,
             )
         # TODO need to move token passing to after encryption has been enabled

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     install_requires=[
         'requests',
         'progressbar==2.2',
+        'pycrypto==2.6.1',
     ],
     scripts=[
         'bin/parcel',


### PR DESCRIPTION
First pass implementation. Adds pubkey handshake to the authentication state.

Requires the addition of pycrypto - could be replaced with C bindings to openssl crypto library. Can then use the bin/gen_keys utility to generate an RSA keypair.

Default behavior is to not try to perform a pubkey handshake if no key files are supplied when the client / server is invoked. New command line option is -K / --keyfile for both server and client.

Needs some work with handling failed authentication.
Needs move of token exchange to something post-encryption setup.

@millerjs ?